### PR TITLE
Fix build warnings

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -12,6 +12,8 @@ set(CMAKE_CXX_STANDARD 17)
 # Creates a pico-sdk subdirectory in our project for the libraries
 pico_sdk_init()
 
+add_compile_options(-Wall)
+
 # Tell CMake where to find the executable source file
 add_executable(${PROJECT_NAME} 
   examples/ST7735_TFT_TESTS/main.cpp

--- a/examples/ST7735_TFT_TESTS/main.cpp
+++ b/examples/ST7735_TFT_TESTS/main.cpp
@@ -575,11 +575,11 @@ void Test11(void)
 			}
 			// display Clock
 			myTFT.TFTFontNum(myTFT.TFTFont_Bignum);
-			sprintf(strTime, "%02u:%02u:%02u", Hour , Min ,Sec);
+			snprintf(strTime, sizeof(strTime), "%02u:%02u:%02u", Hour , Min ,Sec);
 			myTFT.TFTdrawTextNumFont(0, 45, strTime, ST7735_GREEN, ST7735_BLACK);
 			// display counter
 			myTFT.TFTFontNum(myTFT.TFTFont_Mednum);
-			sprintf(strCount, "%03d", count);
+			snprintf(strCount, sizeof(strCount), "%03d", count);
 			myTFT.TFTdrawTextNumFont(0, 85, strCount, ST7735_YELLOW, ST7735_RED);
 			count--;
 		} // if every second

--- a/examples/ST7735_TFT_TESTS/main.cpp
+++ b/examples/ST7735_TFT_TESTS/main.cpp
@@ -575,11 +575,30 @@ void Test11(void)
 			}
 			// display Clock
 			myTFT.TFTFontNum(myTFT.TFTFont_Bignum);
+
+// We just proved that `Hour`, `Min`, and `Sec` are all in their
+// expected range (0-23 for Hour, 0-59 for Min and Sec).  Therefore
+// the 2-character minimum field width specified by the "%02u" format
+// below will not be exceeded.  Disable the format-truncation warning
+// for this line of code only.
+#pragma GCC diagnostic push
+#pragma GCC diagnostic ignored "-Wformat-truncation"
 			snprintf(strTime, sizeof(strTime), "%02u:%02u:%02u", Hour , Min ,Sec);
+#pragma GCC diagnostic pop
+
 			myTFT.TFTdrawTextNumFont(0, 45, strTime, ST7735_GREEN, ST7735_BLACK);
 			// display counter
 			myTFT.TFTFontNum(myTFT.TFTFont_Mednum);
+
+// `count` is in the range 0-20.  Therefore the 2-character minimum
+// field width specified by the "%03d" format below will not be
+// exceeded.  Disable the format-truncation warning for this line of
+// code only.
+#pragma GCC diagnostic push
+#pragma GCC diagnostic ignored "-Wformat-truncation"
 			snprintf(strCount, sizeof(strCount), "%03d", count);
+#pragma GCC diagnostic pop
+
 			myTFT.TFTdrawTextNumFont(0, 85, strCount, ST7735_YELLOW, ST7735_RED);
 			count--;
 		} // if every second

--- a/examples/ST7735_TFT_TESTS/main.cpp
+++ b/examples/ST7735_TFT_TESTS/main.cpp
@@ -568,7 +568,9 @@ void Test11(void)
 				{
 					Hour++;
 					Min = 0;
-					if (Hour == 24)Hour, Min , Sec = 0;
+					if (Hour == 24) {
+						Hour = 0;
+					}
 				}
 			}
 			// display Clock

--- a/src/st7735/ST7735_TFT_Print.cpp
+++ b/src/st7735/ST7735_TFT_Print.cpp
@@ -196,5 +196,5 @@ size_t Print::print(const std::string &s) {
 }
 
 size_t Print::println(const std::string &s) {
-    return println(s);
+    return write(s.c_str(), s.length());
 }


### PR DESCRIPTION
Hi @gavinlyonsrepo, thanks for this super useful project!  I'm using it with a Raspberry Pi Pico and an Adafruit 1.44" display (part 2088) and it's running great.

This PR fixes a couple of compiler warnings, including one that corresponds to an infinite recursion lockup bug, though that code path is not taken by any of the example programs in this repo.