### PR TITLE
Fix (-1,-1) pixel offset in drawSpriteData() / drawBitmap16Data()

### DIFF
--- a/src/displaylib_16/displaylib_16_graphics.cpp
+++ b/src/displaylib_16/displaylib_16_graphics.cpp
@@ -1043,7 +1043,7 @@ DisLib16::Ret_Codes_e displaylib_16_graphics::drawBitmap16Data(uint16_t x, uint1
 			// Extract the 16-bit color from two consecutive bytes
 			color = (*bitmapIter << 8) | *(bitmapIter + 1);
 			bitmapIter += 2;
-			drawPixel(x + i - 1, y + j -1, color);
+			drawPixel(x + i, y + j, color);
 		}
 	}
 #endif
@@ -1103,10 +1103,10 @@ DisLib16::Ret_Codes_e displaylib_16_graphics::drawSpriteData(uint16_t x, uint16_
 			{
 				if (colour != backgroundColor)
 				{
-					drawPixel(x + i - 1, y + j - 1, colour);
+					drawPixel(x + i, y + j, colour);
 				}
 			}else{
-				drawPixel(x + i - 1, y + j - 1, colour);
+				drawPixel(x + i, y + j, colour);
 			}
 		}
 	}


### PR DESCRIPTION
## Problem

`drawSpriteData()` and the `dislib16_ADVANCED_SCREEN_BUFFER_ENABLE` branch of `drawBitmap16Data()` (in `src/displaylib_16/displaylib_16_graphics.cpp`) call:

```cpp
drawPixel(x + i - 1, y + j - 1, colour);
```

but the public API documents `x`/`y` as the top-left origin of the sprite/bitmap, and the sibling implementations (`drawBitmap`, `drawBitmap4Data`, `drawBitmap8Data`, in the same file) all correctly use `x + i, y + j` with no offset.

This causes two observable problems:

- Every sprite/16-bit-buffered-bitmap is drawn one pixel up and to the left of the coordinate the caller passed in.
- When drawing at `x==0` or `y==0`, `i==0`/`j==0` computes `x - 1` / `y - 1`. Since `x`/`y`/`i`/`j` are unsigned (`uint16_t`), this underflows to `65535`, which trips `drawPixel()`'s own bounds check (`x >= _width || y >= _height`) and silently drops the entire first row/column of pixels instead of just shifting them.

## Fix

Remove the erroneous `- 1` from the three affected `drawPixel()` calls so they match the existing convention already used by the other bitmap-drawing functions in this file. No other behavior is changed.

## Testing

Built the unmodified `displaylib_16_graphics.cpp` in a host harness (subclassing the class and overriding the pure-virtual `setAddrWindow()` to record the pixel coordinates actually written), covering both the default `drawSpriteData()` path and the `dislib16_ADVANCED_SCREEN_BUFFER_ENABLE` path of `drawBitmap16Data()`:

- Drawing a 4x3 sprite/bitmap at the origin `(0,0)`: before the fix, only 6 of 12 pixels were written (the rest silently dropped due to the underflow described above); after the fix, all 12 land.
- Drawing the same sprite/bitmap at `(10,10)`: before the fix, the bounding box lands at `(9,9)-(12,11)` instead of the documented `(10,10)-(13,12)`; after the fix it lands exactly on `(10,10)-(13,12)`.
- The sibling function `drawBitmap8Data()` was used as a control and is unaffected by this change (it already lands at the correct coordinates before and after).

Not tested on real RP2040 hardware/display — verified via host-side unit harness against the actual (unmodified) drawing logic.